### PR TITLE
[fix] ChatResponse.process_response 메서드 TypeError 수정

### DIFF
--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -13,8 +13,7 @@ class ChatResponse(BaseModel):
     response: str
     status: str = "success"
     
-    # 의도적 버그: 잘못된 타입 힌트
-    def process_response(self, data: int) -> str:  # data는 실제로 str이어야 함
-        """응답 처리 메서드 - 버그 포함"""
-        # 버그: str을 int로 처리하려고 시도
-        return data + 100  # TypeError 발생 예정
+    def process_response(self, data: str) -> str:
+        """응답 처리 메서드 - 수정된 버전"""
+        # 버그 수정: 올바른 타입 힌트와 구현
+        return f"처리된 응답: {data}"


### PR DESCRIPTION
## 변경 사항
- `ChatResponse.process_response` 메서드의 타입 힌트를 `int`에서 `str`로 수정
- 메서드 구현을 올바른 문자열 처리 방식으로 변경
- TypeError 발생 원인 해결

## 해결된 이슈
Closes #2

## 테스트 완료
- [x] 타입 오류 해결 확인
- [x] 메서드 정상 동작 확인
- [x] 코드 리뷰 완료

## 체크리스트
- [x] 버그 수정 완료
- [x] 타입 힌트 정확성 확인
- [x] 코드 품질 개선

이 PR은 Issue #2에서 보고된 TypeError를 수정합니다.